### PR TITLE
Fix handling of requirements under Python 3 in 'setup.py'.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -91,8 +91,8 @@ def strip_comments(l):
 
 
 def reqs(f):
-    return filter(None, [strip_comments(l) for l in open(
-        os.path.join(os.getcwd(), 'requirements', f)).readlines()])
+    return list(filter(None, [strip_comments(l) for l in open(
+        os.path.join(os.getcwd(), 'requirements', f)).readlines()]))
 
 install_requires = reqs('default.txt')
 if not PY3:


### PR DESCRIPTION
``filter()`` returns an iterator (a ``filter`` object to be precise) under Python 3. Evaluating it to a list is necessary for ``setup`` to behave correctly.