### PR TITLE
Support custom Django User models when populating event message.

### DIFF
--- a/thorn/events.py
+++ b/thorn/events.py
@@ -231,7 +231,7 @@ class ModelEvent(Event):
         return {
             'event': self.name,
             'ref': ref,
-            'sender': sender.username if sender else sender,
+            'sender': sender.get_username() if sender else sender,
             'data': data or {},
         }
 

--- a/thorn/tests/test_events.py
+++ b/thorn/tests/test_events.py
@@ -70,7 +70,7 @@ class test_ModelEvent(EventCase):
         self.event._send.assert_called_with(
             {
                 'event': self.event.name,
-                'sender': sender.username,
+                'sender': sender.get_username(),
                 'ref': self.event.app.reverse.return_value,
                 'data': {'foo': 'bar'},
             },


### PR DESCRIPTION
Django 1.5+ supports custom ``User`` models, and any access to ``username`` should be handled by using ``USERNAME_FIELD`` and ``get_username()``, etc. 1.4 EOL was October 2015, so I'm assuming support for it wasn't a concern. If it is, I can add handling for versions < 1.5. 

The [custom user docs have all the specifics](https://docs.djangoproject.com/en/1.9/topics/auth/customizing/#specifying-a-custom-user-model).