### PR TITLE
allow instance-based formatting for event names

### DIFF
--- a/thorn/tests/case.py
+++ b/thorn/tests/case.py
@@ -7,7 +7,7 @@ from celery import Celery, current_app
 from django.db.models import signals
 
 from thorn import Thorn
-from thorn.events import Event
+from thorn.events import Event, ModelEvent
 from thorn import _state
 
 from nose import SkipTest
@@ -88,6 +88,7 @@ class SignalCase(ThornCase):
 class EventCase(SignalCase):
     Dispatcher = Mock
     Event = Event
+    ModelEvent = ModelEvent
 
     def setUp(self):
         self._prev_app = current_app._get_current_object()
@@ -98,6 +99,14 @@ class EventCase(SignalCase):
 
     def mock_event(self, name, dispatcher=None, app=None, **kwargs):
         return self.Event(
+            name,
+            dispatcher=dispatcher or self.dispatcher,
+            app=app or self.app,
+            **kwargs
+        )
+
+    def mock_modelevent(self, name, dispatcher=None, app=None, **kwargs):
+        return self.ModelEvent(
             name,
             dispatcher=dispatcher or self.dispatcher,
             app=app or self.app,

--- a/thorn/tests/test_events.py
+++ b/thorn/tests/test_events.py
@@ -102,6 +102,7 @@ class test_ModelEvent(EventCase):
             args=[], kwargs={'uuid': instance.uuid},
         )
         self.event._send.assert_called_with(
+            self.event.name,
             {
                 'event': self.event.name,
                 'sender': sender.get_username(),
@@ -125,6 +126,29 @@ class test_ModelEvent(EventCase):
                 },
                 'agent': 'AGENT',
                 'event': 'x.y',
+                'sender': None,
+            },
+            None,
+            on_success=None, on_error=None,
+            timeout=None, on_timeout=None,
+            retry=None, retry_delay=None, retry_max=None,
+            recipient_validators=None,
+            context=None, extra_subscribers=None, allow_keepalive=True,
+        )
+
+    def test_send__with_format_name(self):
+        event = self.mock_modelevent('created.{.occasion}')
+        event.reverse = None
+        instance = Mock(occasion='festivus')
+        event.send(instance, {'foo': 'bar'}, sender=None)
+        self.dispatcher.send.assert_called_with(
+            'created.festivus',
+            {
+                'ref': None,
+                'data': {
+                    'foo': 'bar',
+                },
+                'event': 'created.festivus',
                 'sender': None,
             },
             None,


### PR DESCRIPTION
Allows to subscribers to receive events based on some specific attribute.

For example, a webhook could be defined as:

```python
@webhook_model(
    on_create=ModelEvent('contact.created.{.address_book.name}'),
)
```

and the subscriber could subscribe to `contact.created.work` to only receive events for 'work' contacts.

ref #7 