### PR TITLE
Fixes a possible SSRF in the webhook recipient URL

### DIFF
--- a/thorn/request.py
+++ b/thorn/request.py
@@ -169,6 +169,11 @@ class Request(ThenableProxy):
 
     def to_safeurl(self, url):
         # type: (str) -> Tuple[str, str]
+        # Try and see if there is any sort of redirection in the recipient URL
+        # if yes, get the final URL to be passed into the validator
+        _dummy_resp = requests.get(url, allow_redirects=True)
+        url = _dummy_resp.url
+
         parts = parse_url(url)
         host = parts.host
         addr = socket.gethostbyname(host)

--- a/thorn/request.py
+++ b/thorn/request.py
@@ -171,8 +171,12 @@ class Request(ThenableProxy):
         # type: (str) -> Tuple[str, str]
         # Try and see if there is any sort of redirection in the recipient URL
         # if yes, get the final URL to be passed into the validator
-        _dummy_resp = requests.head(url, allow_redirects=True)
-        url = _dummy_resp.url
+        if self.allow_redirects:
+            try:
+                _dummy_resp = requests.head(url, allow_redirects=True)
+                url = _dummy_resp.url
+            except ConnectionError:
+                logger.warning("Recipient URL not reachable")
 
         parts = parse_url(url)
         host = parts.host

--- a/thorn/request.py
+++ b/thorn/request.py
@@ -171,7 +171,7 @@ class Request(ThenableProxy):
         # type: (str) -> Tuple[str, str]
         # Try and see if there is any sort of redirection in the recipient URL
         # if yes, get the final URL to be passed into the validator
-        _dummy_resp = requests.get(url, allow_redirects=True)
+        _dummy_resp = requests.head(url, allow_redirects=True)
         url = _dummy_resp.url
 
         parts = parse_url(url)


### PR DESCRIPTION
An attacker can possibly access the internal network by choosing a careful receipient URL controlled by them which would do a HTTP redirect (only GET, no POST allowed) to an internal address,
like the AWS metadata URL effectively bypassing an validation checks for port, strict HTTP urls, etc.

A possible malicious URL can be, (basic 3xx redirection): `attacker.com/?to=http://169.254.169.254/latest/user-data`.

This PR resolves the URL and gets the final URL after any/all redirection for the validation checks.