### PR TITLE
Fixed Python 3.7 Syntax Error

### DIFF
--- a/thorn/events.py
+++ b/thorn/events.py
@@ -279,7 +279,7 @@ class ModelEvent(Event):
         # handles this, but we want to avoid the extra database hit
         # when they are not in use.
         self.use_transitions = any(
-            '__now_' in k for k in keys(self.filter_fields),
+            '__now_' in k for k in keys(self.filter_fields)
         )
         # _filterargs is set by __reduce__ to restore *args
         restored_args = kwargs.get('_filterargs') or ()


### PR DESCRIPTION
Python 3.7 changed the syntax https://bugs.python.org/issue32012.
With the comma the below exception is raised.
SyntaxError: Generator expression must be parenthesized