### PR TITLE
Add syntax highlighting to Python code block

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -86,7 +86,7 @@ Example
 This example adds four webhook events to the Article model of
 an imaginary blog engine:
 
-::
+.. sourcecode:: python
 
     from django.urls import reverse
     from thorn import ModelEvent, webhook_model


### PR DESCRIPTION
This is useful for visualizing the nuances in the Python code. The [Faust](https://github.com/robinhood/faust) `README.rst` file also includes such a highlighted code block.